### PR TITLE
Update VimeoClient_Async.cs

### DIFF
--- a/VimeoDotNet/VimeoDotNet/VimeoClient_Async.cs
+++ b/VimeoDotNet/VimeoDotNet/VimeoClient_Async.cs
@@ -343,7 +343,7 @@ namespace VimeoDotNet
             }
             if (metaData.Privacy != VideoPrivacyEnum.Unknown)
             {
-                request.Query.Add("privacy", metaData.Privacy.ToString().ToLower());
+                request.Query.Add("privacy.view", metaData.Privacy.ToString().ToLower());
             }
             request.Query.Add("review_link", metaData.ReviewLinkEnabled.ToString().ToLower());
 


### PR DESCRIPTION
Patching privacy is 'privacy.view', rather than just 'privacy'. Per spec: https://developer.vimeo.com/api/endpoints/videos#/videos/+clip_id.

I am assuming Vimeo changed their API. Tested and validated.
