### PR TITLE
Added test settings

### DIFF
--- a/src/VimeoDotNet.Tests/Settings/SettingsLoader.cs
+++ b/src/VimeoDotNet.Tests/Settings/SettingsLoader.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using Newtonsoft.Json; 
+
+namespace VimeoDotNet.Tests.Settings
+{
+    internal class SettingsLoader
+    {
+        private const string SETTINGS_FILE = "vimeoSettings.json";
+
+        public static VimeoApiTestSettings LoadSettings()
+        {
+            if (!File.Exists(SETTINGS_FILE))
+            {
+                // File was not found so create a new one with blanks 
+                SaveSettings(new VimeoApiTestSettings());
+
+                throw new Exception(string.Format("The file {0} was not found. A file was created, please fill in the information", SETTINGS_FILE));
+            }
+
+            var json = File.ReadAllText(SETTINGS_FILE);
+            return JsonConvert.DeserializeObject<VimeoApiTestSettings>(json);
+        }
+
+        public static void SaveSettings(VimeoApiTestSettings settings)
+        {
+            var json = JsonConvert.SerializeObject(settings, Formatting.Indented);
+            System.IO.File.WriteAllText(SETTINGS_FILE, json);
+        }
+    }
+}

--- a/src/VimeoDotNet.Tests/Settings/VimeoApiTestSettings.cs
+++ b/src/VimeoDotNet.Tests/Settings/VimeoApiTestSettings.cs
@@ -1,0 +1,16 @@
+﻿namespace VimeoDotNet.Tests.Settings
+{
+    internal class VimeoApiTestSettings
+    {
+        // API Client Settings
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public string AccessToken { get; set; }
+
+        // Test Data Settings
+        public long UserId { get; set; }
+        public long AlbumId { get; set; }
+        public long ChannelId { get; set; }
+        public long VideoId { get; set; }
+    }
+}

--- a/src/VimeoDotNet.Tests/VimeoDotNet.Tests.csproj
+++ b/src/VimeoDotNet.Tests/VimeoDotNet.Tests.csproj
@@ -38,6 +38,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -56,6 +60,8 @@
     <Compile Include="..\..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Settings\SettingsLoader.cs" />
+    <Compile Include="Settings\VimeoApiTestSettings.cs" />
     <Compile Include="VimeoClient_IntegrationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/VimeoDotNet.Tests/packages.config
+++ b/src/VimeoDotNet.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Hi, @mfilippov, thanks for this library. I was just about to have to build a vimeo client from scratch. I have built one for the old API and this was the code I used to allow me to keep the sensitive data out of the integration test files. Hope it helps. 

This moves the test settings to a vimeoSettings.json file that is stored
in the /bin folder and therefore not in git. If tests are run and the
file does not exist, it will be generated and an exception is thrown.
This allows contributors to customize the token, album, video, and
userId that is used in integration tests.