### PR TITLE
Speed-ups and Album functions

### DIFF
--- a/src/VimeoDotNet.Tests/VimeoClient_IntegrationTests.cs
+++ b/src/VimeoDotNet.Tests/VimeoClient_IntegrationTests.cs
@@ -211,11 +211,19 @@ namespace VimeoDotNet.Tests
             Assert.IsNotNull(video);
         }
 
+        /// <summary>
+        /// Returns interface to enforce interface completeness
+        /// </summary>
+        /// <returns></returns>
         private IVimeoClient CreateUnauthenticatedClient()
         {
             return new VimeoClient(CLIENTID, CLIENTSECRET);
         }
 
+        /// <summary>
+        /// Returns interface to enforce interface completeness
+        /// </summary>
+        /// <returns></returns>
         private IVimeoClient CreateAuthenticatedClient()
         {
             return new VimeoClient(ACCESSTOKEN);

--- a/src/VimeoDotNet.Tests/VimeoClient_IntegrationTests.cs
+++ b/src/VimeoDotNet.Tests/VimeoClient_IntegrationTests.cs
@@ -10,7 +10,7 @@ namespace VimeoDotNet.Tests
 {
     [TestClass]
     [Ignore] // Comment this line to run integration tests.
-    public class VimeoClient_IntegrationTests
+    public class IVimeoClient_IntegrationTests
     {
         private const string CLIENTID = "<YOUR CLIENT ID HERE>";
         private const string CLIENTSECRET = "<YOUR CLIENT SECRET HERE>";
@@ -23,7 +23,7 @@ namespace VimeoDotNet.Tests
         public void Integration_VimeoClient_GetUploadTicket_CanGenerateStreamingTicket()
         {
             // arrange
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             UploadTicket ticket = client.GetUploadTicket();
@@ -41,7 +41,7 @@ namespace VimeoDotNet.Tests
             using (var file = new BinaryContent(GetFullPath(TESTFILEPATH)))
             {
                 length = file.Data.Length;
-                VimeoClient client = CreateAuthenticatedClient();
+                IVimeoClient client = CreateAuthenticatedClient();
 
                 // act
                 completedRequest = client.UploadEntireFile(file);
@@ -65,7 +65,7 @@ namespace VimeoDotNet.Tests
             using (var file = new BinaryContent(GetFullPath(TESTFILEPATH)))
             {
                 length = file.Data.Length;
-                VimeoClient client = CreateAuthenticatedClient();
+                IVimeoClient client = CreateAuthenticatedClient();
                 // act
                 completedRequest = client.UploadEntireFile(file);
                 Assert.IsTrue(completedRequest.AllBytesWritten);
@@ -84,7 +84,7 @@ namespace VimeoDotNet.Tests
         public void Integration_VimeoClient_GetAccountInformation_RetrievesCurrentAccountInfo()
         {
             // arrange
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             User account = client.GetAccountInformation();
@@ -98,7 +98,7 @@ namespace VimeoDotNet.Tests
         {
             // arrange
             long userId = 8128214;
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             User user = client.GetUserInformation(userId);
@@ -112,7 +112,7 @@ namespace VimeoDotNet.Tests
         public void Integration_VimeoClient_GetAccountVideos_RetrievesCurrentAccountVideos()
         {
             // arrange
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             Paginated<Video> videos = client.GetVideos();
@@ -125,7 +125,7 @@ namespace VimeoDotNet.Tests
         public async Task Integration_VimeoClient_GetAccountVideos_SecondPage()
         {
             // arrange
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             Paginated<Video> videos = await client.GetVideosAsync(page: 2, perPage: 5);
@@ -139,7 +139,7 @@ namespace VimeoDotNet.Tests
         {
             // arrange
             long clipId = 103374506; // Your video ID here
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             Video video = client.GetVideo(clipId);
@@ -154,7 +154,7 @@ namespace VimeoDotNet.Tests
         {
             // arrange
             const long albumId = 2993579; // Your album ID here
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             Paginated<Video> videos = client.GetAlbumVideos(albumId);
@@ -170,7 +170,7 @@ namespace VimeoDotNet.Tests
             // arrange
             const long albumId = 2993579; // Your album ID here
             const long clipId = 103374506; // Your video ID here
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             Video video = client.GetAlbumVideo(albumId, clipId);
@@ -185,7 +185,7 @@ namespace VimeoDotNet.Tests
             // arrange
             const long userId = 6029930; // Your user ID here
             const long albumId = 2993579; // Your album ID here
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             Paginated<Video> videos = client.GetUserAlbumVideos(userId, albumId);
@@ -202,7 +202,7 @@ namespace VimeoDotNet.Tests
             const long userId = 6029930; // Your user ID here
             const long albumId = 2993579; // Your album ID here
             const long clipId = 103374506; // Your video ID here
-            VimeoClient client = CreateAuthenticatedClient();
+            IVimeoClient client = CreateAuthenticatedClient();
 
             // act
             Video video = client.GetUserAlbumVideo(userId, albumId, clipId);
@@ -211,12 +211,12 @@ namespace VimeoDotNet.Tests
             Assert.IsNotNull(video);
         }
 
-        private VimeoClient CreateUnauthenticatedClient()
+        private IVimeoClient CreateUnauthenticatedClient()
         {
             return new VimeoClient(CLIENTID, CLIENTSECRET);
         }
 
-        private VimeoClient CreateAuthenticatedClient()
+        private IVimeoClient CreateAuthenticatedClient()
         {
             return new VimeoClient(ACCESSTOKEN);
         }

--- a/src/VimeoDotNet.Tests/VimeoClient_IntegrationTests.cs
+++ b/src/VimeoDotNet.Tests/VimeoClient_IntegrationTests.cs
@@ -10,7 +10,7 @@ namespace VimeoDotNet.Tests
 {
     [TestClass]
     [Ignore] // Comment this line to run integration tests.
-    public class IVimeoClient_IntegrationTests
+    public class VimeoClient_IntegrationTests
     {
         private const string CLIENTID = "<YOUR CLIENT ID HERE>";
         private const string CLIENTSECRET = "<YOUR CLIENT SECRET HERE>";

--- a/src/VimeoDotNet/IVimeoClient.cs
+++ b/src/VimeoDotNet/IVimeoClient.cs
@@ -17,17 +17,19 @@ namespace VimeoDotNet
         Task<User> GetAccountInformationAsync();
         User GetUserInformation(long userId);
         Task<User> GetUserInformationAsync(long userId);
-        Video GetVideo(long clipId);
-        Task<Video> GetVideoAsync(long clipId);
-        Paginated<Video> GetVideos();
-        Task<Paginated<Video>> GetVideosAsync(int? page, int? perPage);
+        Video GetVideo(long clipId, string fieldsCsv = null);
+        Task<Video> GetVideoAsync(long clipId, string fieldsCsv = null);
+        Paginated<Video> GetVideos(string fieldsCsv = null);
+        Task<Paginated<Video>> GetVideosAsync(int? page, int? perPage, string fieldsCsv = null);
         string GetOauthUrl(string redirectUri, IEnumerable<string> scope, string state);
         UploadTicket GetUploadTicket();
         Task<UploadTicket> GetUploadTicketAsync();
-        Video GetUserVideo(long userId, long clipId);
-        Task<Video> GetUserVideoAsync(long userId, long clipId);
-        Paginated<Video> GetUserVideos(long userId);
-        Task<Paginated<Video>> GetUserVideosAsync(long userId);
+        Video GetUserVideo(long userId, long clipId, string fieldsCsv = null);
+        Task<Video> GetUserVideoAsync(long userId, long clipId, string fieldsCsv = null);
+        Paginated<Video> GetUserVideos(long userId, string fieldsCsv = null);
+        Task<Paginated<Video>> GetUserVideosAsync(long userId, string fieldsCsv = null);
+        Paginated<Video> GetUserVideos(long userId, int? page, int? perPage, string fieldsCsv = null);
+        Task<Paginated<Video>> GetUserVideosAsync(long userId, int? page, int? perPage, string fieldsCsv = null);
         IUploadRequest StartUploadFile(IBinaryContent fileContent, int chunkSize = VimeoClient.DEFAULT_UPLOAD_CHUNK_SIZE);
 
         Task<IUploadRequest> StartUploadFileAsync(IBinaryContent fileContent,
@@ -44,13 +46,17 @@ namespace VimeoDotNet
         VerifyUploadResponse VerifyUploadFile(IUploadRequest uploadRequest);
         Task<VerifyUploadResponse> VerifyUploadFileAsync(IUploadRequest uploadRequest);
 
-        Paginated<Video> GetAlbumVideos(long albumId);
-        Task<Paginated<Video>> GetAlbumVideosAsync(long albumId);
-        Video GetAlbumVideo(long albumId, long clipId);
-        Task<Video> GetAlbumVideoAsync(long albumId, long clipId);
-        Paginated<Video> GetUserAlbumVideos(long userId, long albumId);
-        Task<Paginated<Video>> GetUserAlbumVideosAsync(long userId, long albumId);
-        Video GetUserAlbumVideo(long userId, long albumId, long clipId);
-        Task<Video> GetUserAlbumVideoAsync(long userId, long albumId, long clipId);
+        Paginated<Video> GetAlbumVideos(long albumId, string fieldsCsv = null);
+        Task<Paginated<Video>> GetAlbumVideosAsync(long albumId, int? page, int? perPage, string fieldsCsv = null);
+        Video GetAlbumVideo(long albumId, long clipId, string fieldsCsv = null);
+        Task<Video> GetAlbumVideoAsync(long albumId, long clipId, string fieldsCsv = null);
+        Paginated<Video> GetUserAlbumVideos(long userId, long albumId, int? page = null, int? perPage = null, string fieldsCsv = null);
+        Task<Paginated<Video>> GetUserAlbumVideosAsync(long userId, long albumId, int? page = null, int? perPage = null, string fieldsCsv = null);
+        Video GetUserAlbumVideo(long userId, long albumId, long clipId, string fieldsCsv = null);
+        Task<Video> GetUserAlbumVideoAsync(long userId, long albumId, long clipId, string fieldsCsv = null);
+
+        Paginated<Album> GetAlbums(long? userId, int? page = null, int? perPage = null, string fieldsCsv = null);
+        void AddVideoToAlbum(long? userId, long albumId, long clipId);
+        void RemoveVideoFromAlbum(long? userId, long albumId, long clipId);
     }
 }

--- a/src/VimeoDotNet/Models/Album.cs
+++ b/src/VimeoDotNet/Models/Album.cs
@@ -1,11 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using VimeoDotNet.Helpers;
 
 namespace VimeoDotNet.Models
 {
     [Serializable]
     public class Album
     {
+        public long? id
+        {
+            get { return ModelHelpers.ParseModelUriId(uri); }
+        }
+
         public string uri { get; set; }
         public User user { get; set; }
         public string name { get; set; }

--- a/src/VimeoDotNet/VimeoClient_Sync.cs
+++ b/src/VimeoDotNet/VimeoClient_Sync.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
 using VimeoDotNet.Models;
 using VimeoDotNet.Net;
 
@@ -11,7 +12,7 @@ namespace VimeoDotNet
 
         public AccessTokenResponse GetAccessToken(string authorizationCode, string redirectUrl)
         {
-            return OAuth2Client.GetAccessTokenAsync(authorizationCode, redirectUrl).Result;
+            return Task.Run(async () => await OAuth2Client.GetAccessTokenAsync(authorizationCode, redirectUrl)).Result;
         }
 
         #endregion
@@ -22,7 +23,7 @@ namespace VimeoDotNet
         {
             try
             {
-                return GetAccountInformationAsync().Result;
+                return Task.Run(async () => await GetAccountInformationAsync()).Result;
             }
             catch (AggregateException ex)
             {
@@ -35,7 +36,7 @@ namespace VimeoDotNet
         {
             try
             {
-                return GetUserInformationAsync(userId).Result;
+                return Task.Run(async () => await GetUserInformationAsync(userId)).Result;
             }
             catch (AggregateException ex)
             {
@@ -48,11 +49,11 @@ namespace VimeoDotNet
 
         #region Videos
 
-        public Paginated<Video> GetVideos()
+        public Paginated<Video> GetVideos(string fieldsCsv = null)
         {
             try
             {
-                return GetVideosAsync().Result;
+                return Task.Run(async () => await GetVideosAsync(fieldsCsv:fieldsCsv)).Result;
             }
             catch (AggregateException ex)
             {
@@ -61,11 +62,11 @@ namespace VimeoDotNet
             }
         }
 
-        public Video GetVideo(long clipId)
+        public Video GetVideo(long clipId, string fieldsCsv = null)
         {
             try
             {
-                return GetVideoAsync(clipId).Result;
+                return Task.Run(async () => await GetVideoAsync(clipId, fieldsCsv)).Result;
             }
             catch (AggregateException ex)
             {
@@ -74,16 +75,16 @@ namespace VimeoDotNet
             }
         }
 
-        public Paginated<Video> GetUserVideos(long userId)
+        public Paginated<Video> GetUserVideos(long userId, string fieldsCsv = null)
         {
-            return GetUserVideos(userId, null, null);
+            return GetUserVideos(userId, null, null, fieldsCsv);
         }
 
-        public Paginated<Video> GetUserVideos(long userId, int? page, int? perPage)
+        public Paginated<Video> GetUserVideos(long userId, int? page, int? perPage, string fieldsCsv = null)
         {
             try
             {
-                return GetUserVideosAsync(userId, page, perPage).Result;
+                return Task.Run(async () => await GetUserVideosAsync(userId, page, perPage, fieldsCsv)).Result;
             }
             catch (AggregateException ex)
             {
@@ -92,11 +93,11 @@ namespace VimeoDotNet
             }
         }
 
-        public Video GetUserVideo(long userId, long clipId)
+        public Video GetUserVideo(long userId, long clipId, string fieldsCsv = null)
         {
             try
             {
-                return GetUserVideoAsync(userId, clipId).Result;
+                return Task.Run(async () => await GetUserVideoAsync(userId, clipId)).Result;
             }
             catch (AggregateException ex)
             {
@@ -105,11 +106,11 @@ namespace VimeoDotNet
             }
         }
 
-        public Paginated<Video> GetAlbumVideos(long albumId)
+        public Paginated<Video> GetAlbumVideos(long albumId, string fieldsCsv = null)
         {
             try
             {
-                return GetAlbumVideosAsync(albumId).Result;
+                return Task.Run(async () => await GetAlbumVideosAsync(albumId)).Result;
             }
             catch (AggregateException ex)
             {
@@ -118,11 +119,11 @@ namespace VimeoDotNet
             }
         }
 
-        public Video GetAlbumVideo(long albumId, long clipId)
+        public Video GetAlbumVideo(long albumId, long clipId, string fieldsCsv = null)
         {
             try
             {
-                return GetAlbumVideoAsync(albumId, clipId).Result;
+                return Task.Run(async () => await GetAlbumVideoAsync(albumId, clipId)).Result;
             }
             catch (AggregateException ex)
             {
@@ -131,11 +132,11 @@ namespace VimeoDotNet
             }
         }
 
-        public Paginated<Video> GetUserAlbumVideos(long userId, long albumId)
+        public Paginated<Video> GetUserAlbumVideos(long userId, long albumId, int? page = null, int? perPage = null, string fieldsCsv = null)
         {
             try
             {
-                return GetUserAlbumVideosAsync(userId, albumId).Result;
+                return Task.Run(async () => await GetUserAlbumVideosAsync(userId, albumId, page, perPage, fieldsCsv)).Result;
             }
             catch (AggregateException ex)
             {
@@ -144,11 +145,14 @@ namespace VimeoDotNet
             }
         }
 
-        public Video GetUserAlbumVideo(long userId, long albumId, long clipId)
+
+
+
+        public Video GetUserAlbumVideo(long userId, long albumId, long clipId, string fieldsCsv = null)
         {
             try
             {
-                return GetUserAlbumVideoAsync(userId, albumId, clipId).Result;
+                return Task.Run(async () => await GetUserAlbumVideoAsync(userId, albumId, clipId)).Result;
             }
             catch (AggregateException ex)
             {
@@ -183,13 +187,52 @@ namespace VimeoDotNet
 
         #endregion
 
+        #region Album
+        public Paginated<Album> GetAlbums(long? userId, int? page = null, int? perPage = null, string fieldsCsv = null)
+        {
+            try
+            {
+                return Task.Run(async () => await GetAlbumsAsync(userId, page, perPage, fieldsCsv)).Result;
+            }
+            catch (AggregateException ex)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                return null;
+            }
+        }
+
+        public void AddVideoToAlbum(long? userId, long albumId, long clipId)
+        {
+            try
+            {
+                AddVideoToAlbumAsync(userId, albumId, clipId).Wait();
+            }
+            catch (AggregateException ex)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            }
+        }
+        public void RemoveVideoFromAlbum(long? userId, long albumId, long clipId)
+        {
+            try
+            {
+                RemoveVideoFromAlbumAsynch(userId, albumId, clipId).Wait();
+            }
+            catch (AggregateException ex)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            }
+        }
+        #endregion
+
+
         #region Upload
 
         public UploadTicket GetUploadTicket()
         {
             try
             {
-                return GetUploadTicketAsync().Result;
+                return Task.Run(async () => await GetUploadTicketAsync()).Result;
             }
             catch (AggregateException ex)
             {
@@ -202,7 +245,7 @@ namespace VimeoDotNet
         {
             try
             {
-                return StartUploadFileAsync(fileContent, chunkSize).Result;
+                return Task.Run(async () => await StartUploadFileAsync(fileContent, chunkSize)).Result;
             }
             catch (AggregateException ex)
             {
@@ -215,7 +258,7 @@ namespace VimeoDotNet
         {
             try
             {
-                return UploadEntireFileAsync(fileContent, chunkSize).Result;
+                return Task.Run(async () => await UploadEntireFileAsync(fileContent, chunkSize)).Result;
             }
             catch (AggregateException ex)
             {
@@ -228,7 +271,7 @@ namespace VimeoDotNet
         {
             try
             {
-                return ContinueUploadFileAsync(uploadRequest).Result;
+                return Task.Run(async () => await ContinueUploadFileAsync(uploadRequest)).Result;
             }
             catch (AggregateException ex)
             {
@@ -241,7 +284,7 @@ namespace VimeoDotNet
         {
             try
             {
-                return VerifyUploadFileAsync(uploadRequest).Result;
+                return Task.Run(async () => await VerifyUploadFileAsync(uploadRequest)).Result;
             }
             catch (AggregateException ex)
             {

--- a/src/VimeoDotNet/VimeoClient_Videos.cs
+++ b/src/VimeoDotNet/VimeoClient_Videos.cs
@@ -31,11 +31,11 @@ namespace VimeoDotNet
             }
         }
 
-        public async Task<Video> GetAlbumVideoAsync(long albumId, long clipId)
+        public async Task<Video> GetAlbumVideoAsync(long albumId, long clipId, string fieldsCsv = null)
         {
             try
             {
-                IApiRequest request = GenerateAlbumVideosRequest(albumId, clipId: clipId);
+                IApiRequest request = GenerateAlbumVideosRequest(userId: null, albumId: albumId, clipId: clipId, fieldsCsv: fieldsCsv);
                 IRestResponse<Video> response = await request.ExecuteRequestAsync<Video>();
                 CheckStatusCodeError(response, "Error retrieving user album video.", HttpStatusCode.NotFound);
 
@@ -55,11 +55,11 @@ namespace VimeoDotNet
             }
         }
 
-        public async Task<Paginated<Video>> GetAlbumVideosAsync(long albumId)
+        public async Task<Paginated<Video>> GetAlbumVideosAsync(long albumId, int? page = null, int? perPage = null, string fieldsCsv = null)
         {
             try
             {
-                IApiRequest request = GenerateAlbumVideosRequest(albumId);
+                IApiRequest request = GenerateAlbumVideosRequest(userId: null, albumId: albumId, page: page, perPage: perPage, fieldsCsv: fieldsCsv);
                 IRestResponse<Paginated<Video>> response = await request.ExecuteRequestAsync<Paginated<Video>>();
                 CheckStatusCodeError(response, "Error retrieving account album videos.");
 
@@ -75,11 +75,11 @@ namespace VimeoDotNet
             }
         }
 
-        public async Task<Video> GetUserAlbumVideoAsync(long userId, long albumId, long clipId)
+        public async Task<Video> GetUserAlbumVideoAsync(long userId, long albumId, long clipId, string fieldsCsv = null)
         {
             try
             {
-                IApiRequest request = GenerateAlbumVideosRequest(albumId, userId, clipId);
+                IApiRequest request = GenerateAlbumVideosRequest(userId, albumId, clipId: clipId);
                 IRestResponse<Video> response = await request.ExecuteRequestAsync<Video>();
                 CheckStatusCodeError(response, "Error retrieving user album video.", HttpStatusCode.NotFound);
 
@@ -99,11 +99,11 @@ namespace VimeoDotNet
             }
         }
 
-        public async Task<Paginated<Video>> GetUserAlbumVideosAsync(long userId, long albumId)
+        public async Task<Paginated<Video>> GetUserAlbumVideosAsync(long userId, long albumId, int? page = null, int? perPage = null, string fieldsCsv = null)
         {
             try
             {
-                IApiRequest request = GenerateAlbumVideosRequest(albumId, userId);
+                IApiRequest request = GenerateAlbumVideosRequest(userId, albumId, page: page, perPage: perPage, fieldsCsv: fieldsCsv);
                 IRestResponse<Paginated<Video>> response = await request.ExecuteRequestAsync<Paginated<Video>>();
                 CheckStatusCodeError(response, "Error retrieving user album videos.", HttpStatusCode.NotFound);
 
@@ -128,11 +128,56 @@ namespace VimeoDotNet
             }
         }
 
-        public async Task<Video> GetUserVideoAsync(long userId, long clipId)
+
+        public async Task AddVideoToAlbumAsync(long? userId, long albumId, long clipId)
+        {
+            string errMsg = "Error adding video to album.";
+            try
+            {
+                IApiRequest request = GenerateAlbumAddVideoRequest(userId, albumId, clipId);
+                IRestResponse response = await request.ExecuteRequestAsync();
+                CheckStatusCodeError(response, errMsg, HttpStatusCode.NotFound);
+
+            }
+            catch (Exception ex)
+            {
+                if (ex is VimeoApiException)
+                {
+                    throw;
+                }
+                throw new VimeoApiException(errMsg, ex);
+            }
+        }
+        public async Task RemoveVideoFromAlbumAsynch(long? userId, long albumId, long clipId)
+        {
+            string errMsg = "Error adding video to album.";
+            try
+            {
+                IApiRequest request = GenerateAlbumRemoveVideoRequest(userId, albumId, clipId);
+                IRestResponse response = await request.ExecuteRequestAsync();
+                CheckStatusCodeError(response, errMsg, HttpStatusCode.NotFound);
+
+            }
+            catch (Exception ex)
+            {
+                if (ex is VimeoApiException)
+                {
+                    throw;
+                }
+                throw new VimeoApiException(errMsg, ex);
+            }
+        }
+
+
+
+
+
+
+        public async Task<Video> GetUserVideoAsync(long userId, long clipId, string fieldsCsv = null)
         {
             try
             {
-                IApiRequest request = GenerateVideosRequest(userId, clipId);
+                IApiRequest request = GenerateVideosRequest(userId, clipId, fieldsCsv: fieldsCsv);
                 IRestResponse<Video> response = await request.ExecuteRequestAsync<Video>();
                 CheckStatusCodeError(response, "Error retrieving user video.", HttpStatusCode.NotFound);
 
@@ -152,16 +197,16 @@ namespace VimeoDotNet
             }
         }
 
-        public async Task<Paginated<Video>> GetUserVideosAsync(long userId)
+        public async Task<Paginated<Video>> GetUserVideosAsync(long userId, string fieldsCsv = null)
         {
             return await GetUserVideosAsync(userId, null, null);
         }
 
-        public async Task<Paginated<Video>> GetUserVideosAsync(long userId, int? page, int? perPage)
+        public async Task<Paginated<Video>> GetUserVideosAsync(long userId, int? page, int? perPage, string fieldsCsv = null)
         {
             try
             {
-                IApiRequest request = GenerateVideosRequest(userId: userId, page: page, perPage: perPage);
+                IApiRequest request = GenerateVideosRequest(userId: userId, page: page, perPage: perPage, fieldsCsv: fieldsCsv);
                 IRestResponse<Paginated<Video>> response = await request.ExecuteRequestAsync<Paginated<Video>>();
                 CheckStatusCodeError(response, "Error retrieving user videos.", HttpStatusCode.NotFound);
 
@@ -186,11 +231,11 @@ namespace VimeoDotNet
             }
         }
 
-        public async Task<Video> GetVideoAsync(long clipId)
+        public async Task<Video> GetVideoAsync(long clipId, string fieldsCsv = null)
         {
             try
             {
-                IApiRequest request = GenerateVideosRequest(clipId: clipId);
+                IApiRequest request = GenerateVideosRequest(clipId: clipId, fieldsCsv: fieldsCsv);
                 IRestResponse<Video> response = await request.ExecuteRequestAsync<Video>();
                 CheckStatusCodeError(response, "Error retrieving account video.", HttpStatusCode.NotFound);
 
@@ -210,11 +255,11 @@ namespace VimeoDotNet
             }
         }
 
-        public async Task<Paginated<Video>> GetVideosAsync(int? page = null, int? perPage = null)
+        public async Task<Paginated<Video>> GetVideosAsync(int? page = null, int? perPage = null, string fieldsCsv = null)
         {
             try
             {
-                IApiRequest request = GenerateVideosRequest(page: page, perPage: perPage);
+                IApiRequest request = GenerateVideosRequest(page: page, perPage: perPage, fieldsCsv: fieldsCsv);
                 IRestResponse<Paginated<Video>> response = await request.ExecuteRequestAsync<Paginated<Video>>();
                 CheckStatusCodeError(response, "Error retrieving account videos.");
 
@@ -247,8 +292,8 @@ namespace VimeoDotNet
                 throw new VimeoApiException("Error updating user video metadata.", ex);
             }
         }
-        
-        private IApiRequest GenerateVideosRequest(long? userId = null, long? clipId = null, int? page = null, int? perPage = null)
+
+        private IApiRequest GenerateVideosRequest(long? userId = null, long? clipId = null, int? page = null, int? perPage = null, string fieldsCsv = null)
         {
             ThrowIfUnauthorized();
 
@@ -275,11 +320,56 @@ namespace VimeoDotNet
             {
                 request.Query.Add("per_page", perPage.ToString());
             }
+            if(!string.IsNullOrWhiteSpace(fieldsCsv))
+            {
+                request.Query.Add("fields", fieldsCsv);
+            }
 
             return request;
         }
 
-        private IApiRequest GenerateAlbumVideosRequest(long albumId, long? userId = null, long? clipId = null)
+
+
+        private IApiRequest GenerateAlbumRequest(long? userId = null, long? albumId = null, int? page = null, int? perPage = null, string fieldsCsv = null)
+        {
+            ThrowIfUnauthorized();
+
+            IApiRequest request = _apiRequestFactory.GetApiRequest(AccessToken);
+            string endpoint = userId.HasValue
+                ? albumId.HasValue ? Endpoints.UserAlbum : Endpoints.UserAlbums
+                : albumId.HasValue ? Endpoints.Album : Endpoints.Albums;
+            request.Method = Method.GET;
+            request.Path = endpoint;
+
+            if (userId.HasValue)
+            {
+                request.UrlSegments.Add("userId", userId.ToString());
+            }
+            if (albumId.HasValue)
+            {
+                request.UrlSegments.Add("clipId", albumId.ToString());
+            }
+            if (page.HasValue)
+            {
+                request.Query.Add("page", page.ToString());
+            }
+            if (perPage.HasValue)
+            {
+                request.Query.Add("per_page", perPage.ToString());
+            }
+            if (!string.IsNullOrWhiteSpace(fieldsCsv))
+            {
+                request.Query.Add("fields", fieldsCsv);
+            }
+
+            return request;
+        }
+
+
+
+
+
+        private IApiRequest GenerateAlbumVideosRequest(long? userId, long albumId, int? page = null, int? perPage = null, long? clipId = null, string fieldsCsv = null)
         {
             ThrowIfUnauthorized();
 
@@ -297,9 +387,78 @@ namespace VimeoDotNet
             {
                 request.UrlSegments.Add("clipId", clipId.ToString());
             }
+            if (page.HasValue)
+            {
+                request.Query.Add("page", page.ToString());
+            }
+            if (perPage.HasValue)
+            {
+                request.Query.Add("per_page", perPage.ToString());
+            }
+            if (!string.IsNullOrWhiteSpace(fieldsCsv))
+            {
+                request.Query.Add("fields", fieldsCsv);
+            }
 
             return request;
         }
+
+
+
+
+        private IApiRequest GenerateAlbumAddVideoRequest(long? userId, long albumId, long clipId)
+        {
+            ThrowIfUnauthorized();
+
+            IApiRequest request = _apiRequestFactory.GetApiRequest(AccessToken);
+            string endpoint = Endpoints.UserAlbumVideo;
+            request.Method = Method.PUT;
+            request.Path = userId.HasValue ? endpoint : Endpoints.GetCurrentUserEndpoint(endpoint);
+
+            request.UrlSegments.Add("albumId", albumId.ToString());
+            if (userId.HasValue)
+            {
+                request.UrlSegments.Add("userId", userId.ToString());
+            }
+            request.UrlSegments.Add("clipId", clipId.ToString());
+
+            return request;
+        }
+
+
+        private IApiRequest GenerateAlbumRemoveVideoRequest(long? userId, long albumId , long clipId)
+        {
+            IApiRequest request = GenerateAlbumAddVideoRequest(userId, albumId, clipId);
+            request.Method = Method.DELETE;
+
+            return request;
+        }
+
+
+        public async Task<Paginated<Album>> GetAlbumsAsync(long? userId, int? page = null, int? perPage = null, string fieldsCsv = null)
+        {
+            string errMsg = "Error retrieving albums";
+
+            try
+            {
+                IApiRequest request = GenerateAlbumRequest(userId:userId, page:page, perPage:perPage, fieldsCsv: fieldsCsv);
+
+                IRestResponse<Paginated<Album>> response = await request.ExecuteRequestAsync<Paginated<Album>>();
+                CheckStatusCodeError(response, errMsg);
+
+                return response.Data;
+            }
+            catch (Exception ex)
+            {
+                if (ex is VimeoApiException)
+                {
+                    throw;
+                }
+                throw new VimeoApiException(errMsg, ex);
+            }
+        }
+
+
 
         private IApiRequest GenerateVideoDeleteRequest(long clipId)
         {


### PR DESCRIPTION
This is my first ever pull request so please bear with me if I screw this up. Here's the updates included:

- All functions returning Video or Album objects have a new optional parameter "fieldsCsv" which allows the caller to select a subset of properties returned from the vimeo API. [Vimeo docs:]( https://developer.vimeo.com/api/spec#common-parameters). Using this feature can increase speed by orders of magnitude (i.e. 10x or much more). For example, if you just want a list of video names and id's, you can pass "name,uri" to fieldsCsv (uri yields both uri and id since the Video class extracts id from uri)
- Added some Album ("Collections" on Vimeo) related functions such as add / remove movies from Album. 
- Added some overloads to IVimeoClient to support user-specific versions of functions. 
- Added id property to Album class (as per Video class)
- Tests use IVimeoClient instead of VimeoClient to ensure new functions added to client are added to interface
