### PR TITLE
Upgrade RestSharp to 105.2.3

### DIFF
--- a/src/VimeoDotNet.Net45/VimeoDotNet.Net45.csproj
+++ b/src/VimeoDotNet.Net45/VimeoDotNet.Net45.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\VimeoDotNet.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RestSharp.105.1.0\lib\net45\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/VimeoDotNet.Net45/packages.config
+++ b/src/VimeoDotNet.Net45/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net45" userInstalled="true" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/src/VimeoDotNet.Net451/VimeoDotNet.Net451.csproj
+++ b/src/VimeoDotNet.Net451/VimeoDotNet.Net451.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\VimeoDotNet.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RestSharp.105.1.0\lib\net451\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RestSharp.105.2.3\lib\net451\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/VimeoDotNet.Net451/packages.config
+++ b/src/VimeoDotNet.Net451/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net451" userInstalled="true" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net451" userInstalled="true" />
 </packages>

--- a/src/VimeoDotNet.Net452/VimeoDotNet.Net452.csproj
+++ b/src/VimeoDotNet.Net452/VimeoDotNet.Net452.csproj
@@ -31,8 +31,8 @@
     <DocumentationFile>bin\Release\VimeoDotNet.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RestSharp.105.1.0\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RestSharp.105.2.3\lib\net452\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/VimeoDotNet.Net452/packages.config
+++ b/src/VimeoDotNet.Net452/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net452" userInstalled="true" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net452" userInstalled="true" />
 </packages>

--- a/src/VimeoDotNet.Net46/VimeoDotNet.Net46.csproj
+++ b/src/VimeoDotNet.Net46/VimeoDotNet.Net46.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\VimeoDotNet.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RestSharp.105.1.0\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/VimeoDotNet.Net46/packages.config
+++ b/src/VimeoDotNet.Net46/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net46" userInstalled="true" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net46" userInstalled="true" />
 </packages>

--- a/src/VimeoDotNet/Authorization/AuthorizationClient.cs
+++ b/src/VimeoDotNet/Authorization/AuthorizationClient.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using RestSharp;
-using RestSharp.Contrib;
+using RestSharp.Extensions.MonoHttp;
 using VimeoDotNet.Constants;
 using VimeoDotNet.Models;
 using VimeoDotNet.Net;

--- a/src/VimeoDotNet/Net/ApiRequest.cs
+++ b/src/VimeoDotNet/Net/ApiRequest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using RestSharp;
+using RestSharp.Authenticators;
 using VimeoDotNet.Constants;
 
 namespace VimeoDotNet.Net

--- a/src/VimeoDotNet/VimeoDotNet.csproj
+++ b/src/VimeoDotNet/VimeoDotNet.csproj
@@ -33,8 +33,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RestSharp.105.1.0\lib\net451\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RestSharp.105.2.3\lib\net451\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/VimeoDotNet/packages.config
+++ b/src/VimeoDotNet/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net451" userInstalled="true" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net451" userInstalled="true" />
 </packages>


### PR DESCRIPTION
Fixes #37

As of RestSharp 105.2.0 some of the namespaces have changed.