### PR TITLE
Fix RestSharp version in .nuspec

### DIFF
--- a/VimeoDotNet.nuspec
+++ b/VimeoDotNet.nuspec
@@ -21,7 +21,7 @@
             <tags>vimeo, async</tags>
             <dependencies>
                 <group>
-                    <dependency id="RestSharp" version="105.1.0" />
+                    <dependency id="RestSharp" version="105.2.3" />
                 </group>
             </dependencies>
         </metadata>


### PR DESCRIPTION
Fixes #88 

Just need to build and upload a new version of the NuGet package.