### PR TITLE
Issue #96 Fix

### DIFF
--- a/src/VimeoDotNet/VimeoClient_Upload.cs
+++ b/src/VimeoDotNet/VimeoClient_Upload.cs
@@ -376,7 +376,8 @@ namespace VimeoDotNet
                 {
                     var startIndex = fileContent.Data.CanSeek ? fileContent.Data.Position : written;
                     var endIndex = Math.Min(startIndex + chunkSize.Value, fileContent.Data.Length);
-                    request.Body = new ByteArrayContent(await fileContent.ReadAsync(startIndex, endIndex), (int)startIndex, (int)endIndex);
+                    var byteArray = await fileContent.ReadAsync(startIndex, endIndex);
+                    request.Body = new ByteArrayContent(byteArray, 0, byteArray.Length);
                 }
                 else
                 {


### PR DESCRIPTION
GenerateFileStreamRequest was going outside the bounds of the byte array instead of just using 0 and the byte arrays length.