### PR TITLE
Add ablity to verify an access token and fix bugs in GetAccessToken

### DIFF
--- a/src/VimeoDotNet.Tests/AuthorizationClientAsyncTests.cs
+++ b/src/VimeoDotNet.Tests/AuthorizationClientAsyncTests.cs
@@ -26,5 +26,16 @@ namespace VimeoDotNet.Tests
             token.access_token.ShouldNotBeNull();
             token.user.ShouldBeNull();
         }
+
+        [Fact]
+        public async Task VerifyAuthenticatedAccess()
+        {
+            var client = new AuthorizationClient(_vimeoSettings.ClientId, _vimeoSettings.ClientSecret);
+
+            var b = await client.VerifyAccessTokenAsync(_vimeoSettings.AccessToken);
+            b.ShouldBeTrue();
+            b = await client.VerifyAccessTokenAsync("abadaccesstoken");
+            b.ShouldBeFalse();
+        }
     }
 }

--- a/src/VimeoDotNet/Authorization/AuthorizationClient.cs
+++ b/src/VimeoDotNet/Authorization/AuthorizationClient.cs
@@ -74,6 +74,24 @@ namespace VimeoDotNet.Authorization
         }
 
         /// <inheritdoc />
+        public Boolean VerifyAccessToken(string AccessToken)
+        {
+            return VerifyAccessTokenAsync(AccessToken).Result;
+        }
+
+        /// <inheritdoc />
+        public async Task<Boolean> VerifyAccessTokenAsync(string AccessToken)
+        {
+            var request = GenerateVerifyRequest(AccessToken);
+            var result = await request.ExecuteRequestAsync();
+            if (result.StatusCode == HttpStatusCode.OK)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <inheritdoc />
         public async Task<AccessTokenResponse> GetUnauthenticatedTokenAsync()
         {
             var request = BuildUnauthenticatedTokenRequest();
@@ -140,6 +158,16 @@ namespace VimeoDotNet.Authorization
                 Path = Endpoints.AccessToken
             };
             SetAccessTokenQueryParams(request, authorizationCode, redirectUri);
+
+            return request;
+        }
+
+        private IApiRequest GenerateVerifyRequest(string AccessToken)
+        {
+            IApiRequest request = new ApiRequest(AccessToken);
+            string endpoint = Endpoints.Verify;
+            request.Method = HttpMethod.Get;
+            request.Path = endpoint;
 
             return request;
         }

--- a/src/VimeoDotNet/Authorization/IAuthorizationClient.cs
+++ b/src/VimeoDotNet/Authorization/IAuthorizationClient.cs
@@ -26,6 +26,20 @@ namespace VimeoDotNet.Authorization
         /// <returns>Access token response</returns>
         Task<AccessTokenResponse> GetAccessTokenAsync(string authorizationCode, string redirectUri);
         /// <summary>
+        /// VerifyAccessToken
+        /// </summary>
+        /// <param name="accessToken">AccessToken</param>
+        /// <returns>true if access token works, false otherwise</returns>
+        /// [Obsolete("Use async API instead sync wrapper")]
+        bool VerifyAccessToken(string accessToken);
+        /// <summary>
+        /// VerifyAccessToken
+        /// </summary>
+        /// <param name="accessToken">AccessToken</param>
+        /// <returns>true if access token works, false otherwise</returns>
+        /// [Obsolete("Use async API instead sync wrapper")]
+        Task<bool> VerifyAccessTokenAsync(string accessToken);
+        /// <summary>
         /// Return unauthenticated token
         /// </summary>
         /// <returns>Access token response</returns>

--- a/src/VimeoDotNet/Constants/Endpoints.cs
+++ b/src/VimeoDotNet/Constants/Endpoints.cs
@@ -4,6 +4,7 @@
     {
         public const string Authorize = "/oauth/authorize";
         public const string AccessToken = "/oauth/access_token";
+        public const string Verify = "/oauth/verify";
         public const string AuthorizeClient = "/oauth/authorize/client";
 
         public const string Albums = "/albums";

--- a/src/VimeoDotNet/Models/AccessTokenResponse.cs
+++ b/src/VimeoDotNet/Models/AccessTokenResponse.cs
@@ -14,6 +14,16 @@ namespace VimeoDotNet.Models
         public string access_token { get; set; }
 
         /// <summary>
+        /// The type of token (Vimeo only supports Bearer at the moment)
+        /// </summary>
+        public string token_type { get; set; }
+
+        /// <summary>
+        /// The final scopes the token was granted. This list MAY be different from the scopes you requested. This will be the actual permissions the token has been granted.
+        /// </summary>
+        public string scope { get; set; }
+
+        /// <summary>
         /// This is the full user response for the authenticated user.
         /// If you generated your token using the client credentials grant, this value is left out.
         /// </summary>


### PR DESCRIPTION
see https://developer.vimeo.com/api/endpoints/authenticationextras#GET/oauth/verify 
Solves #109 

Also fixed GetAccessToken bugs:
 - Add error handling.
 - must be a form post, not query string params.
 - Add missing fields to AccessTokenResponse.