### PR TITLE
Working with embed presets

### DIFF
--- a/src/VimeoDotNet.Tests/EmbedPresetsTests.cs
+++ b/src/VimeoDotNet.Tests/EmbedPresetsTests.cs
@@ -1,0 +1,99 @@
+﻿using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using VimeoDotNet.Exceptions;
+using VimeoDotNet.Models;
+using Xunit;
+
+namespace VimeoDotNet.Tests
+{
+    public class EmbedPresetsTests : BaseTest
+    {
+        [Fact]
+        public async Task ShouldCorrectlyRetrieveMyEmbedPresetById()
+        {
+            var client = CreateAuthenticatedClient();
+            var preset = await client.GetEmbedPresetAsync(UserId.Me, VimeoSettings.EmbedPresetId);
+            preset.ShouldNotBeNull();
+            preset.Id.ShouldBe(VimeoSettings.EmbedPresetId);
+        }
+
+        [Fact]
+        public async Task ShouldCorrectlyRetrieveUserEmbedPresetById()
+        {
+            var client = CreateAuthenticatedClient();
+            var preset = await client.GetEmbedPresetAsync(VimeoSettings.UserId, VimeoSettings.EmbedPresetId);
+            preset.ShouldNotBeNull();
+            preset.Id.ShouldBe(VimeoSettings.EmbedPresetId);
+        }
+
+        [Fact]
+        public async Task ShouldCorrectlyRetrieveMyEmbedPresets()
+        {
+            var client = CreateAuthenticatedClient();
+            var presets = await client.GetEmbedPresetsAsync(UserId.Me);
+            presets.ShouldNotBeNull();
+            presets.Data.Count.ShouldBeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task ShouldCorrectlyRetrieveUserEmbedPresets()
+        {
+            var client = CreateAuthenticatedClient();
+            var presets = await client.GetEmbedPresetsAsync(VimeoSettings.UserId);
+            presets.ShouldNotBeNull();
+            presets.Data.Count.ShouldBeGreaterThan(0);
+        }
+
+        [Fact]
+        public async Task ShouldCorrectlyGetEmbedPresetWithFields()
+        {
+            var client = CreateAuthenticatedClient();
+            var preset = await client.GetEmbedPresetAsync(UserId.Me, VimeoSettings.EmbedPresetId, new[] { "uri", "name" });
+            preset.ShouldNotBeNull();
+            preset.Uri.ShouldNotBeNull();
+            preset.Name.ShouldNotBeNull();
+            preset.Settings.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task ShouldCorrectlyGetEmbedPresetsWithFields()
+        {
+            var client = CreateAuthenticatedClient();
+            var presets = await client.GetEmbedPresetsAsync(UserId.Me, fields: new[] { "uri", "name" });
+            presets.ShouldNotBeNull();
+            presets.Data.Count.ShouldBeGreaterThan(0);
+            presets.Data[0].ShouldNotBeNull();
+            presets.Data[0].Uri.ShouldNotBeNull();
+            presets.Data[0].Name.ShouldNotBeNull();
+            presets.Data[0].Settings.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task ShouldCorrectlyRetrieveSecondPage()
+        {
+            var client = CreateAuthenticatedClient();
+
+            for (var i = 0; i < 5; i++)
+            {
+                try
+                {
+                    var presets = await client.GetEmbedPresetsAsync(UserId.Me, 2, 1);
+                    presets.ShouldNotBeNull();
+                    return;
+                }
+                catch (VimeoApiException ex)
+                {
+                    if (ex.Message.Contains("Please try again."))
+                    {
+                        continue;
+                    }
+
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/VimeoDotNet.Tests/EmbedPresetsTests.cs
+++ b/src/VimeoDotNet.Tests/EmbedPresetsTests.cs
@@ -14,6 +14,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyRetrieveMyEmbedPresetById()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
             var preset = await client.GetEmbedPresetAsync(UserId.Me, VimeoSettings.EmbedPresetId);
             preset.ShouldNotBeNull();
@@ -23,6 +26,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyRetrieveUserEmbedPresetById()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
             var preset = await client.GetEmbedPresetAsync(VimeoSettings.UserId, VimeoSettings.EmbedPresetId);
             preset.ShouldNotBeNull();
@@ -32,6 +38,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyRetrieveMyEmbedPresets()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
             var presets = await client.GetEmbedPresetsAsync(UserId.Me);
             presets.ShouldNotBeNull();
@@ -41,6 +50,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyRetrieveUserEmbedPresets()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
             var presets = await client.GetEmbedPresetsAsync(VimeoSettings.UserId);
             presets.ShouldNotBeNull();
@@ -50,6 +62,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyGetEmbedPresetWithFields()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
             var preset = await client.GetEmbedPresetAsync(UserId.Me, VimeoSettings.EmbedPresetId, new[] { "uri", "name" });
             preset.ShouldNotBeNull();
@@ -61,6 +76,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyGetEmbedPresetsWithFields()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
             var presets = await client.GetEmbedPresetsAsync(UserId.Me, fields: new[] { "uri", "name" });
             presets.ShouldNotBeNull();
@@ -74,6 +92,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyRetrieveSecondPage()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
 
             for (var i = 0; i < 5; i++)

--- a/src/VimeoDotNet.Tests/Settings/SettingsLoader.cs
+++ b/src/VimeoDotNet.Tests/Settings/SettingsLoader.cs
@@ -32,6 +32,7 @@ namespace VimeoDotNet.Tests.Settings
             long.TryParse(Environment.GetEnvironmentVariable("AlbumId"), out var albumId);
             long.TryParse(Environment.GetEnvironmentVariable("VideoId"), out var videoId);
             long.TryParse(Environment.GetEnvironmentVariable("TextTrackId"), out var textTrackId);
+            long.TryParse(Environment.GetEnvironmentVariable("EmbedPresetId"), out var embedPresetId);
             long.TryParse(Environment.GetEnvironmentVariable("PublicUserId"), out var publicUserId);
             return new VimeoApiTestSettings
             {
@@ -42,6 +43,7 @@ namespace VimeoDotNet.Tests.Settings
                 AlbumId = albumId,
                 VideoId = videoId,
                 TextTrackId = textTrackId,
+                EmbedPresetId = embedPresetId,
                 PublicUserId = publicUserId
             };
         }

--- a/src/VimeoDotNet.Tests/Settings/VimeoApiTestSettings.cs
+++ b/src/VimeoDotNet.Tests/Settings/VimeoApiTestSettings.cs
@@ -12,6 +12,7 @@
         public long AlbumId { get; set; }
         public long VideoId { get; set; }
         public long TextTrackId { get; set; }
+        public long EmbedPresetId { get; set; }
 
         public long PublicUserId { get; set; }
     }

--- a/src/VimeoDotNet.Tests/VideoTests.cs
+++ b/src/VimeoDotNet.Tests/VideoTests.cs
@@ -186,6 +186,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyAssignEmbedPresetToVideo()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
             await client.AssignEmbedPresetToVideoAsync(VimeoSettings.VideoId, VimeoSettings.EmbedPresetId);
             var video = await client.GetVideoAsync(VimeoSettings.VideoId, new[] { "embed_presets" });
@@ -197,6 +200,9 @@ namespace VimeoDotNet.Tests
         [Fact]
         public async Task ShouldCorrectlyUnassignEmbedPresetFromVideo()
         {
+            if (VimeoSettings.EmbedPresetId == 0)
+                return;
+
             var client = CreateAuthenticatedClient();
             var video = await client.GetVideoAsync(VimeoSettings.VideoId, new[] { "embed_presets" });
             var oldPresetId = video?.EmbedPresets?.Id;

--- a/src/VimeoDotNet.Tests/VideoTests.cs
+++ b/src/VimeoDotNet.Tests/VideoTests.cs
@@ -182,5 +182,35 @@ namespace VimeoDotNet.Tests
             var pictureById = await client.GetPictureAsync(VimeoSettings.VideoId, pictureId);
             pictureById.ShouldNotBeNull();
         }
+
+        [Fact]
+        public async Task ShouldCorrectlyAssignEmbedPresetToVideo()
+        {
+            var client = CreateAuthenticatedClient();
+            await client.AssignEmbedPresetToVideoAsync(VimeoSettings.VideoId, VimeoSettings.EmbedPresetId);
+            var video = await client.GetVideoAsync(VimeoSettings.VideoId, new[] { "embed_presets" });
+            video.ShouldNotBeNull();
+            video.EmbedPresets.ShouldNotBeNull();
+            video.EmbedPresets.Id.ShouldBe(VimeoSettings.EmbedPresetId);
+        }
+
+        [Fact]
+        public async Task ShouldCorrectlyUnassignEmbedPresetFromVideo()
+        {
+            var client = CreateAuthenticatedClient();
+            var video = await client.GetVideoAsync(VimeoSettings.VideoId, new[] { "embed_presets" });
+            var oldPresetId = video?.EmbedPresets?.Id;
+            await client.UnassignEmbedPresetFromVideoAsync(VimeoSettings.VideoId, VimeoSettings.EmbedPresetId);
+            video = await client.GetVideoAsync(VimeoSettings.VideoId, new[] { "embed_presets" });
+            video.ShouldNotBeNull();
+            if (oldPresetId == VimeoSettings.EmbedPresetId)
+            {
+                video.EmbedPresets.ShouldBeNull();
+            }
+            else
+            {
+                video.EmbedPresets?.Id.ShouldBe(oldPresetId);
+            }
+        }
     }
 }

--- a/src/VimeoDotNet/IVimeoClient.cs
+++ b/src/VimeoDotNet/IVimeoClient.cs
@@ -354,5 +354,28 @@ namespace VimeoDotNet
             int? perPage = null, GetVideoByTagSort? sort = null, GetVideoByTagDirection? direction = null, string[] fields = null);
 
         #endregion
+
+        #region EmbedPresets
+
+        /// <summary>
+        /// Get embed preset by user ID and preset ID asynchronously
+        /// </summary>
+        /// <param name="userId">User ID</param>
+        /// <param name="presetId">Preset ID</param>
+        /// <param name="fields">JSON filter, as per https://developer.vimeo.com/api/common-formats#json-filter</param>
+        /// <returns>Embed preset</returns>
+        Task<EmbedPresets> GetEmbedPresetAsync(UserId userId, long presetId, string[] fields = null);
+
+        /// <summary>
+        /// Get embed presets by user ID and page parameters asynchronously
+        /// </summary>
+        /// <param name="userId">UserId</param>
+        /// <param name="page">The page number to show</param>
+        /// <param name="perPage">Number of items to show on each page. Max 50</param>
+        /// <param name="fields">JSON filter, as per https://developer.vimeo.com/api/common-formats#json-filter</param>
+        /// <returns>Paginated embed presets</returns>
+        Task<Paginated<EmbedPresets>> GetEmbedPresetsAsync(UserId userId, int? page = null, int? perPage = null, string[] fields = null);
+
+        #endregion
     }
 }

--- a/src/VimeoDotNet/IVimeoClient.cs
+++ b/src/VimeoDotNet/IVimeoClient.cs
@@ -114,6 +114,20 @@ namespace VimeoDotNet
         Task UpdateVideoMetadataAsync(long clipId, VideoUpdateMetadata metaData);
 
         /// <summary>
+        /// Assign an embed preset to a video asynchronously
+        /// </summary>
+        /// <param name="clipId">Clip ID</param>
+        /// <param name="presetId">Preset ID</param>
+        Task AssignEmbedPresetToVideoAsync(long clipId, long presetId);
+
+        /// <summary>
+        /// Unassign an embed preset from a video asynchronously
+        /// </summary>
+        /// <param name="clipId">Clip ID</param>
+        /// <param name="presetId">Preset ID</param>
+        Task UnassignEmbedPresetFromVideoAsync(long clipId, long presetId);
+
+        /// <summary>
         /// Delete video asynchronously
         /// </summary>
         /// <param name="clipId">CliepId</param>

--- a/src/VimeoDotNet/VimeoClient_EmbedPresets.cs
+++ b/src/VimeoDotNet/VimeoClient_EmbedPresets.cs
@@ -23,13 +23,12 @@ namespace VimeoDotNet
 
                 return response.StatusCode == HttpStatusCode.NotFound ? null : response.Content;
             }
+            catch (VimeoApiException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                if (ex is VimeoApiException)
-                {
-                    throw;
-                }
-
                 throw new VimeoApiException("Error retrieving user embed preset.", ex);
             }
         }
@@ -46,13 +45,12 @@ namespace VimeoDotNet
 
                 return response.StatusCode == HttpStatusCode.NotFound ? null : response.Content;
             }
+            catch (VimeoApiException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                if (ex is VimeoApiException)
-                {
-                    throw;
-                }
-
                 throw new VimeoApiException("Error retrieving user embed presets.", ex);
             }
         }

--- a/src/VimeoDotNet/VimeoClient_EmbedPresets.cs
+++ b/src/VimeoDotNet/VimeoClient_EmbedPresets.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using VimeoDotNet.Constants;
+using VimeoDotNet.Exceptions;
+using VimeoDotNet.Models;
+using VimeoDotNet.Net;
+
+namespace VimeoDotNet
+{
+    public partial class VimeoClient
+    {
+        /// <inheritdoc />
+        public async Task<EmbedPresets> GetEmbedPresetAsync(UserId userId, long presetId, string[] fields = null)
+        {
+            try
+            {
+                var request = GenerateEmbedPresetsRequest(userId: userId, presetId: presetId, fields: fields);
+                var response = await request.ExecuteRequestAsync<EmbedPresets>().ConfigureAwait(false);
+                UpdateRateLimit(response);
+                CheckStatusCodeError(response, "Error retrieving user embed preset.", HttpStatusCode.NotFound);
+
+                return response.StatusCode == HttpStatusCode.NotFound ? null : response.Content;
+            }
+            catch (Exception ex)
+            {
+                if (ex is VimeoApiException)
+                {
+                    throw;
+                }
+
+                throw new VimeoApiException("Error retrieving user embed preset.", ex);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<Paginated<EmbedPresets>> GetEmbedPresetsAsync(UserId userId, int? page = null, int? perPage = null, string[] fields = null)
+        {
+            try
+            {
+                var request = GenerateEmbedPresetsRequest(userId: userId, page: page, perPage: perPage, fields: fields);
+                var response = await request.ExecuteRequestAsync<Paginated<EmbedPresets>>().ConfigureAwait(false);
+                UpdateRateLimit(response);
+                CheckStatusCodeError(response, "Error retrieving user embed presets.", HttpStatusCode.NotFound);
+
+                return response.StatusCode == HttpStatusCode.NotFound ? null : response.Content;
+            }
+            catch (Exception ex)
+            {
+                if (ex is VimeoApiException)
+                {
+                    throw;
+                }
+
+                throw new VimeoApiException("Error retrieving user embed presets.", ex);
+            }
+        }
+
+        private IApiRequest GenerateEmbedPresetsRequest(UserId userId, long? presetId = null, int? page = null,
+            int? perPage = null, string[] fields = null)
+        {
+            ThrowIfUnauthorized();
+
+            var request = _apiRequestFactory.GetApiRequest(AccessToken);
+            string endpoint;
+            if (userId?.IsMe == true)
+            {
+                endpoint = presetId.HasValue
+                    ? Endpoints.GetCurrentUserEndpoint(Endpoints.UserPreset)
+                    : Endpoints.GetCurrentUserEndpoint(Endpoints.UserPresets);
+            }
+            else
+            {
+                endpoint = presetId.HasValue ? Endpoints.UserPreset : Endpoints.UserPresets;
+            }
+
+            request.Method = HttpMethod.Get;
+            request.Path = endpoint;
+
+            if (userId?.IsMe == false)
+            {
+                request.UrlSegments.Add("userId", userId.ToString());
+            }
+
+            if (presetId.HasValue)
+            {
+                request.UrlSegments.Add("presetId", presetId.ToString());
+            }
+
+            if (fields != null)
+            {
+                foreach (var field in fields)
+                {
+                    request.Fields.Add(field);
+                }
+            }
+
+            if (page.HasValue)
+            {
+                request.Query.Add("page", page.ToString());
+            }
+
+            if (perPage.HasValue)
+            {
+                request.Query.Add("per_page", perPage.ToString());
+            }
+
+            return request;
+        }
+    }
+}


### PR DESCRIPTION
Hi @mfilippov thanks for your great Vimeo client.

I've implemented a few additions for working with embed presets.
- **GetEmbedPresetAsync** - to get embed preset by user ID and preset ID
- **GetEmbedPresetsAsync** - to get all embed presets by user ID
- **AssignEmbedPresetToVideoAsync** - to assign an embed preset to a video
- **UnassignEmbedPresetFromVideoAsync** - to unassign an embed preset from a video

There are a few things which can be debated:
- When unassigning preset from a video, I ignore 404 error only if preset not found, but throw when video not found. I think it's convenient, but may be better to leave handling of errors to a user.
- Currently model class for preset is named in plural **EmbedPresets**. It was nice when it only used for corresponding field in video data. But brings a bit of confusion after introducing new methods. Probably it would be better to rename it to singular but of course this is a breaking change.