### PR TITLE
Methods for working with domains for embedding videos

### DIFF
--- a/src/VimeoDotNet/Enums/AccountTypeEnum.cs
+++ b/src/VimeoDotNet/Enums/AccountTypeEnum.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// Pro account
         /// </summary>
-        Pro
+        Pro,
+
+        /// <summary>
+        /// Pro Unlimited account
+        /// </summary>
+        ProUnlimited
     }
 }

--- a/src/VimeoDotNet/IVimeoClient.cs
+++ b/src/VimeoDotNet/IVimeoClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using VimeoDotNet.Enums;
 using VimeoDotNet.Exceptions;
 using VimeoDotNet.Models;
 using VimeoDotNet.Net;
@@ -84,12 +85,57 @@ namespace VimeoDotNet
             string sort = null, string direction = null, string[] fields = null);
 
         /// <summary>
+        /// Allows a video to be embedded on specified domain asynchronously.
+        /// </summary>
+        /// <param name="clipId">ClipId</param>
+        /// <param name="domain">Domain</param>
+        /// <remarks>
+        /// The call is valid only when video embed privacy is set to
+        /// <see cref="VideoEmbedPrivacyEnum.Whitelist"/>.
+        /// Use <see cref="UpdateVideoMetadataAsync(long, VideoUpdateMetadata)"/> and
+        /// <see cref="VideoUpdateMetadata.EmbedPrivacy"/> property to change this setting.
+        /// </remarks>
+        /// <seealso cref="DisallowEmbedVideoOnDomainAsync(long, string)"/>
+        /// <seealso cref="GetAllowedDomainsForEmbeddingVideoAsync(long)"/>
+        Task AllowEmbedVideoOnDomainAsync(long clipId, string domain);
+
+        /// <summary>
+        /// Disallows a video to be embedded on specified domain asynchronously.
+        /// </summary>
+        /// <param name="clipId">ClipId</param>
+        /// <param name="domain">Domain</param>
+        /// <remarks>
+        /// The call is valid only when video embed privacy is set to
+        /// <see cref="VideoEmbedPrivacyEnum.Whitelist"/>.
+        /// Use <see cref="UpdateVideoMetadataAsync(long, VideoUpdateMetadata)"/> and
+        /// <see cref="VideoUpdateMetadata.EmbedPrivacy"/> property to change this setting.
+        /// </remarks>
+        /// <seealso cref="AllowEmbedVideoOnDomainAsync(long, string)"/>
+        /// <seealso cref="GetAllowedDomainsForEmbeddingVideoAsync(long)"/>
+        Task DisallowEmbedVideoOnDomainAsync(long clipId, string domain);
+
+        /// <summary>
+        /// Get all domains on which a video can be embedded.
+        /// </summary>
+        /// <param name="clipId">ClipId</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// The call is valid only when video embed privacy is set to
+        /// <see cref="VideoEmbedPrivacyEnum.Whitelist"/>.
+        /// Use <see cref="UpdateVideoMetadataAsync(long, VideoUpdateMetadata)"/> and
+        /// <see cref="VideoUpdateMetadata.EmbedPrivacy"/> property to change this setting.
+        /// </remarks>
+        /// <seealso cref="AllowEmbedVideoOnDomainAsync(long, string)"/>
+        /// <seealso cref="DisallowEmbedVideoOnDomainAsync(long, string)"/>
+        Task<Paginated<DomainForEmbedding>> GetAllowedDomainsForEmbeddingVideoAsync(long clipId);
+
+        /// <summary>
         /// Update allowed domain for clip asynchronously
         /// </summary>
         /// <param name="clipId">ClipId</param>
         /// <param name="domain">Domain</param>
+        [Obsolete("Use AllowEmbedVideoOnDomainAsync instead.")]
         Task UpdateVideoAllowedDomainAsync(long clipId, string domain);
-
 
         /// <summary>
         /// Get all thumbnails on a video

--- a/src/VimeoDotNet/Models/DomainForEmbedding.cs
+++ b/src/VimeoDotNet/Models/DomainForEmbedding.cs
@@ -1,0 +1,32 @@
+﻿using JetBrains.Annotations;
+using Newtonsoft.Json;
+
+namespace VimeoDotNet.Models
+{
+    /// <summary>
+    /// Domain for embedding a video
+    /// </summary>
+    public class DomainForEmbedding
+    {
+        /// <summary>
+        /// Domain name
+        /// </summary>
+        [PublicAPI]
+        [JsonProperty(PropertyName = "domain")]
+        public string Domain { get; set; }
+
+        /// <summary>
+        /// Whether HD quality is allowed
+        /// </summary>
+        [PublicAPI]
+        [JsonProperty(PropertyName = "allow_hd")]
+        public bool AllowHighDefinition { get; set; }
+
+        /// <summary>
+        /// URI of this resource
+        /// </summary>
+        [PublicAPI]
+        [JsonProperty(PropertyName = "uri")]
+        public string Uri { get; set; }
+    }
+}

--- a/src/VimeoDotNet/Models/User.cs
+++ b/src/VimeoDotNet/Models/User.cs
@@ -12,6 +12,11 @@ namespace VimeoDotNet.Models
     /// </summary>
     public class User
     {
+        private static readonly IDictionary<string, string> AccountTypeMappings = new Dictionary<string, string>
+        {
+            {"pro_unlimited", "ProUnlimited"}
+        };
+
         /// <summary>
         /// Id
         /// </summary>
@@ -114,7 +119,7 @@ namespace VimeoDotNet.Models
         [PublicAPI]
         public AccountTypeEnum AccountType
         {
-            get => ModelHelpers.GetEnumValue<AccountTypeEnum>(Account);
+            get => ModelHelpers.GetEnumValue<AccountTypeEnum>(Account, AccountTypeMappings);
             set => Account = ModelHelpers.GetEnumString(value);
         }
     }


### PR DESCRIPTION
Hi @mfilippov 

These are the changes I've promised regarding whitelist domains for embedding (issue #82). Sorry for being a bit slower than expected :)

It turned out that not only tests were needed but some additions to API.
I've decided to rename existing **UpdateVideoAllowedDomainAsync** to **AllowEmbedVideoOnDomainAsync** for better clarity. However, I pertained the old method for compatibility, just marked it as obsolete.

I used Vimeo account type to decide whether to skip the test. I can add a flag to test settings instead if you think it will be better.

BTW I've also added ProUnlimited to **AccountTypeEnum** as this the type of account I use for testing. It would be great to add other missing types as well. I could not find a list of possible values for account types though. I suppose this info can be requested from Vimeo support if needed.