### PR TITLE
Expose player embed url

### DIFF
--- a/src/VimeoDotNet/Enums/VideoPrivacyEnum.cs
+++ b/src/VimeoDotNet/Enums/VideoPrivacyEnum.cs
@@ -1,4 +1,6 @@
-﻿namespace VimeoDotNet.Enums
+﻿using System;
+
+namespace VimeoDotNet.Enums
 {
     /// <summary>
     /// View privacy
@@ -6,37 +8,40 @@
     public enum VideoPrivacyEnum
     {
         /// <summary>
-        /// Nobody
+        /// Nobody - No one except the owner can access the video. This privacy setting appears as Private on the Vimeo front end.
         /// </summary>
         Nobody,
 
         /// <summary>
-        /// Anybody
+        /// Anybody - Anyone can access the video. This privacy setting appears as Public on the Vimeo front end.
         /// </summary>
         Anybody,
 
         /// <summary>
-        /// Only contacts
+        /// Contacts - Only those who follow the owner on Vimeo can access the video.
         /// </summary>
+        [Obsolete]
         Contacts,
 
         /// <summary>
-        /// Only users
+        /// Users - Only Vimeo members can access the video.
         /// </summary>
+        [Obsolete]
         Users,
 
         /// <summary>
-        /// Password
+        /// Password - Only those with the password can access the video.
         /// </summary>
         Password,
 
         /// <summary>
-        /// Disable
+        /// Disable - The video is embeddable, but it's hidden on Vimeo and can't be played. This privacy setting appears as Hide from Vimeo on the Vimeo front end.
         /// </summary>
+        [Obsolete]
         Disable,
 
         /// <summary>
-        /// Unlisted
+        /// Unlisted - Only those with the private link can access the video.
         /// </summary>
         Unlisted
     }

--- a/src/VimeoDotNet/Models/Video.cs
+++ b/src/VimeoDotNet/Models/Video.cs
@@ -11,6 +11,7 @@ namespace VimeoDotNet.Models
     /// <summary>
     /// Video
     /// </summary>
+    // https://developer.vimeo.com/api/reference/response/video
     public class Video
     {
         private static readonly IDictionary<string, string> StatusMappings = new Dictionary<string, string>
@@ -57,6 +58,13 @@ namespace VimeoDotNet.Models
         [PublicAPI]
         [JsonProperty(PropertyName = "link")]
         public string Link { get; set; }
+
+        /// <summary>
+        /// player_embed_url
+        /// </summary>
+        [PublicAPI]
+        [JsonProperty(PropertyName = "player_embed_url")]
+        public string Player_Embed_Url { get; set; }
 
         /// <summary>
         /// Review link

--- a/src/VimeoDotNet/Models/Video.cs
+++ b/src/VimeoDotNet/Models/Video.cs
@@ -60,7 +60,7 @@ namespace VimeoDotNet.Models
         public string Link { get; set; }
 
         /// <summary>
-        /// player_embed_url
+        /// The video's player embed URL
         /// </summary>
         [PublicAPI]
         [JsonProperty(PropertyName = "player_embed_url")]


### PR DESCRIPTION
Starting January 21, 2025 vimeo will automatically disable old embed codes or videos without the the 'h' parameter for private / unlisted videos see: https://help.vimeo.com/hc/en-us/articles/13741122177169-FAQ-Enhancing-the-security-of-Vimeo-embeds-