### PR TITLE
Fix 'Free space error' for free users or if the uploaded file were bigger than the free space

### DIFF
--- a/src/VimeoDotNet/VimeoClient_Upload.cs
+++ b/src/VimeoDotNet/VimeoClient_Upload.cs
@@ -318,7 +318,7 @@ namespace VimeoDotNet
         private async Task<IApiRequest> GenerateFileStreamRequest(IBinaryContent fileContent, UploadTicket ticket,
             long chunkSize, long written = 0, bool verifyOnly = false)
         {
-            if (fileContent.Data.Length > ticket.User.UploadQuota.Space.Free)
+            if (ticket.User.UploadQuota.Space.Free == 0)
             {
                  throw new InvalidOperationException(
                      "User does not have enough free space to upload this video. Remaining space: " +


### PR DESCRIPTION
Free space is not measured in bytes but in video quantity, so it must be checked if there is at least one free space to use instead of checking if file lenght is bigger than the free space.