### PR TITLE
fix: removing unneeded wrong response type

### DIFF
--- a/src/VimeoDotNet/Models/UserMetadata.cs
+++ b/src/VimeoDotNet/Models/UserMetadata.cs
@@ -17,13 +17,6 @@ namespace VimeoDotNet.Models
         public UserConnections Connections { get; set; }
 
         /// <summary>
-        /// Interactions
-        /// </summary>
-        [PublicAPI]
-        [JsonProperty(PropertyName = "interactions")]
-        public UserInteractions Interactions { get; set; }
-
-        /// <summary>
         /// Follower
         /// </summary>
         [PublicAPI]


### PR DESCRIPTION
This change addresses an issue where we have a wrong response type from the Vimeo API to the third party SDK wrapper. Documenting here for an official git diff.