### PR TITLE
make duration nullabe to avoid error

### DIFF
--- a/src/VimeoDotNet/Models/Video.cs
+++ b/src/VimeoDotNet/Models/Video.cs
@@ -130,7 +130,7 @@ namespace VimeoDotNet.Models
         /// <value>The duration.</value>
         [PublicAPI]
         [JsonProperty(PropertyName = "duration")]
-        public int Duration { get; set; }
+        public int? Duration { get; set; }
 
         /// <summary>
         /// Width


### PR DESCRIPTION
The request for replacing a source video Id returns some fields as null and it isn't currently handled. 
Example:
![WhatsApp Image 2025-01-28 at 13 09 35 (1)](https://github.com/user-attachments/assets/b6e102de-8188-4c47-af21-3f5a3fe17d33)
